### PR TITLE
Add alternate link tag to wrapAtom

### DIFF
--- a/codalib/bagatom.py
+++ b/codalib/bagatom.py
@@ -25,7 +25,7 @@ NODE = "{%s}" % NODE_NAMESPACE
 NODE_NSMAP = {"node": NODE_NAMESPACE}
 
 
-def wrapAtom(xml, id, title, author=None, updated=None, author_uri=None):
+def wrapAtom(xml, id, title, author=None, updated=None, author_uri=None, alt=None):
     """
     Create an Atom entry tag and embed the passed XML within it
     """
@@ -36,6 +36,14 @@ def wrapAtom(xml, id, title, author=None, updated=None, author_uri=None):
     idTag = etree.SubElement(entryTag, ATOM + "id")
     idTag.text = id
     updatedTag = etree.SubElement(entryTag, ATOM + "updated")
+
+    if alt:
+        etree.SubElement(
+            entryTag,
+            ATOM + "link",
+            rel='alternate',
+            href=alt)
+
     if updated != None:
         updatedTag.text = updated.strftime(TIME_FORMAT_STRING)
     else:

--- a/tests/bagatom/test_wrapAtom.py
+++ b/tests/bagatom/test_wrapAtom.py
@@ -206,7 +206,7 @@ def test_content_is_preserved():
 
 def test_has_alternate_relationship_link():
     """
-    Verify that the content is preserved after it has been wrapped.
+    Verify the entry has an alternate link.
     """
     root = etree.fromstring(xml)
     atom = bagatom.wrapAtom(root, '934023', 'test', alt='http://example.com')
@@ -216,4 +216,3 @@ def test_has_alternate_relationship_link():
         namespaces={'a': bagatom.ATOM_NAMESPACE})
 
     assert link[0].get('href') == 'http://example.com'
-    print etree.tostring(atom, pretty_print=True)

--- a/tests/bagatom/test_wrapAtom.py
+++ b/tests/bagatom/test_wrapAtom.py
@@ -202,3 +202,18 @@ def test_content_is_preserved():
         namespaces={'a': bagatom.ATOM_NAMESPACE}
     )
     assert xml.strip() in etree.tostring(content[0])
+
+
+def test_has_alternate_relationship_link():
+    """
+    Verify that the content is preserved after it has been wrapped.
+    """
+    root = etree.fromstring(xml)
+    atom = bagatom.wrapAtom(root, '934023', 'test', alt='http://example.com')
+
+    link = atom.xpath(
+        "/a:entry/a:link[@rel='alternate']",
+        namespaces={'a': bagatom.ATOM_NAMESPACE})
+
+    assert link[0].get('href') == 'http://example.com'
+    print etree.tostring(atom, pretty_print=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+[flake8]
+max-line-length = 99
+
 [tox]
 envlist = py27,flake8
 


### PR DESCRIPTION
This add the `alt` keyword argument to the the `wrapAtom` function.
##### Example

``` python
from bagatom import wrapAtom

xml = # ...
wrapAtom(xml, '934023', 'test', alt='http://example.com')
```

``` xml
<!-- OUTPUT -->
<entry xmlns="http://www.w3.org/2005/Atom">
  <title>test</title>
  <id>934023</id>
  <updated>2016-02-08T23:18:56Z</updated>
  <link href="http://example.com" rel="alternate"/>
  <content type="application/xml">
    <note>
      <to>Tove</to>
      <from>Jani</from>
      <heading>Reminder</heading>
      <body>Don't forget me this weekend!</body>
    </note>
  </content>
</entry>

```
