### PR TITLE
Patch for alt links in Atom feed entry entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.2
+-----
+
+* Remove hard-coded reference to `bag` collection in Atom feed entry `alt` links. [#18](https://github.com/unt-libraries/codalib/issues/18)
+
 1.0.1
 -----
 

--- a/codalib/__init__.py
+++ b/codalib/__init__.py
@@ -3,7 +3,7 @@
 __title__ = "Coda"
 __uri__ = "http://digital2.library.unt.edu/name/nm0004311/"
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 APP_AUTHOR = {
     "name": __title__,

--- a/codalib/bagatom.py
+++ b/codalib/bagatom.py
@@ -374,11 +374,16 @@ def makeObjectFeed(
             dateStamp = getattr(o, dateAttr)
         else:
             dateStamp = None
+        althref = feedId.strip('/').split('/')[-1]
+        althref = '%s/%s/%s/' % (
+            webRoot, althref, getattr(o, idAttr)
+        )
         objectEntry = wrapAtom(
             xml=objectXML,
             id='%s/%s%s/' % (webRoot, originalId, getattr(o, idAttr)),
             title=getattr(o, nameAttr),
-            updated=dateStamp,  alt=webRoot+"/bag/"+getattr(o, idAttr),
+            updated=dateStamp,
+            alt=althref
         )
         feedTag.append(objectEntry)
     return feedTag

--- a/tests/bagatom/test_makeObjectFeed.py
+++ b/tests/bagatom/test_makeObjectFeed.py
@@ -37,7 +37,7 @@ def test_simpleFeed():
     page_return.has_previous = Mock(return_value=False)
     paginator.page = Mock(return_value=page_return)
     dummy_obj2xml_func = Mock(return_value=oxml)
-    feed_id = 'APP/bag/'
+    feed_id = 'APP/randomcollection/'
     title = 'Bag Feed'
     web_root = 'http://localhost:8787'
 
@@ -49,4 +49,7 @@ def test_simpleFeed():
         namespaces={'a': atom_ns}
     )
     assert len(elements) == 1
-    assert elements[0].attrib["type"] == "text/html"
+    assert elements[0].attrib['type'] == 'text/html'
+    assert elements[0].attrib['href'] == '%s/%s/%s/' % (
+        web_root, 'randomcollection', obj.id
+    )


### PR DESCRIPTION
This is a small fix for alt links in Atom feed entries. Previously, the collection name `bag` was hardcoded. This change makes assumptions about collection names, assumptions which hold, in practice. Unless something else comes up, I think this would be rolled into a patch release (1.0.2) in the near-term.