### PR TITLE
closes #21, more precise element selection in mapping xml to objects …

### DIFF
--- a/codalib/bagatom.py
+++ b/codalib/bagatom.py
@@ -22,6 +22,8 @@ NODE_NAMESPACE = "http://digital2.library.unt.edu/coda/nodexml/"
 NODE = "{%s}" % NODE_NAMESPACE
 NODE_NSMAP = {"node": NODE_NAMESPACE}
 
+DEFAULT_ARK_NAAN = 67531
+
 
 def wrapAtom(xml, id, title, author=None, updated=None, author_uri=None,
              alt=None, alt_type="text/html"):
@@ -95,16 +97,20 @@ def getBagTags(bagInfoPath):
     return bagTags
 
 
-def bagToXML(bagPath):
+def bagToXML(bagPath, ark_naan=None):
     """
     Given a path to a bag, read stuff about it and make an XML file
     """
+    # This is so .DEFAULT_ARK_NAAN can be modified
+    # at runtime.
+    if ark_naan is None:
+        ark_naan = DEFAULT_ARK_NAAN
     bagInfoPath = os.path.join(bagPath, "bag-info.txt")
     bagTags = getBagTags(bagInfoPath)
     if 'Payload-Oxum' not in bagTags:
         bagTags['Payload-Oxum'] = getOxum(os.path.join(bagPath, "data"))
     oxumParts = bagTags['Payload-Oxum'].split(".", 1)
-    bagName = "ark:/67531/" + os.path.split(bagPath)[1]
+    bagName = "ark:/%d/" % ark_naan + os.path.split(bagPath)[1]
     bagSize = oxumParts[0]
     bagFileCount = oxumParts[1]
     bagitString = open(os.path.join(bagPath, "bagit.txt"), "r").read()

--- a/codalib/bagatom.py
+++ b/codalib/bagatom.py
@@ -110,7 +110,7 @@ def bagToXML(bagPath, ark_naan=None):
     if 'Payload-Oxum' not in bagTags:
         bagTags['Payload-Oxum'] = getOxum(os.path.join(bagPath, "data"))
     oxumParts = bagTags['Payload-Oxum'].split(".", 1)
-    bagName = "ark:/%d/" % ark_naan + os.path.split(bagPath)[1]
+    bagName = "ark:/%d/%s" % (ark_naan, os.path.split(bagPath)[1])
     bagSize = oxumParts[0]
     bagFileCount = oxumParts[1]
     bagitString = open(os.path.join(bagPath, "bagit.txt"), "r").read()
@@ -470,7 +470,7 @@ def updateObjectFromXML(xml_doc, obj, mapping):
             selector = '/'.join(v)
         else:
             raise TypeError(
-                'Invalid tag-to-property mapping dict: ' +
+                'Invalid tag-to-property mapping dict: '
                 'values must be strings or lists, not %s.' % (type(v),)
             )
         try:

--- a/tests/bagatom/test_bagToXML.py
+++ b/tests/bagatom/test_bagToXML.py
@@ -70,7 +70,6 @@ def bagxml_with_bagging_date(monkeypatch):
     Test fixture that patches the following functions:
         open()
         bagatom.getBagTags()
-        bagatom.getOxum()
 
     Returns a predefined set of tags, including the
     Bagging-Date tag.
@@ -92,7 +91,6 @@ def bagxml_with_nondefault_ark(monkeypatch):
     Test fixture that patches the following functions:
         open()
         bagatom.getBagTags()
-        bagatom.getOxum()
 
     Returns a predefined set of tags, including the
     Bagging-Date tag. Sets ark to non-default value.

--- a/tests/bagatom/test_bagToXML.py
+++ b/tests/bagatom/test_bagToXML.py
@@ -236,7 +236,7 @@ def test_return_tree_with_baggingDate(bagxml_with_bagging_date):
 def test_set_ark_nan(bagxml_with_nondefault_ark):
     """
     Check that the ARK NAAN is properly set and that it both can be
-    changed at runtime by a library user and defaults to 67531.
+    changed at runtime by a library user.
     """
     bagxml = bagxml_with_nondefault_ark
     bag_el, ark = bagxml

--- a/tests/bagatom/test_bagToXML.py
+++ b/tests/bagatom/test_bagToXML.py
@@ -235,7 +235,7 @@ def test_return_tree_with_baggingDate(bagxml_with_bagging_date):
 
 def test_set_ark_nan(bagxml_with_nondefault_ark):
     """
-    Check that the ARK NAAN is properly set and that it both can be
+    Check that the ARK NAAN is properly set and that it can be
     changed at runtime by a library user.
     """
     bagxml = bagxml_with_nondefault_ark

--- a/tests/bagatom/test_updateObjectFromXML.py
+++ b/tests/bagatom/test_updateObjectFromXML.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from lxml import etree
 import pytest
 
@@ -192,9 +190,9 @@ def test_mapping_w_namespaces(event_atom, mini_mock):
     map_dict['@namespaces'] = {
         'premis': 'info:lc/xmlns/premis-v2'
     }
-    map_dict['event_outcome'] = 'premis:eventOutcomeInformation' +\
+    map_dict['event_outcome'] = 'premis:eventOutcomeInformation' + \
         '/premis:eventOutcome'
-    map_dict['event_outcome_detail'] = 'premis:eventOutcomeInformation' +\
+    map_dict['event_outcome_detail'] = 'premis:eventOutcomeInformation' + \
         '/premis:eventOutcomeDetail/premis:eventOutcomeDetailNote'
     expected = 'http://purl.org/net/untl/vocabularies/eventOutcomes/#success'
     event = mini_mock()

--- a/tests/bagatom/test_updateObjectFromXML.py
+++ b/tests/bagatom/test_updateObjectFromXML.py
@@ -102,7 +102,9 @@ def test_object_properties_match_xml(person_xml, mini_mock):
     person0.nickname = None
     person0.first_name = None
 
-    person1 = deepcopy(person0)
+    person1 = mini_mock()
+    person1.nickname = None
+    person1.first_name = None
 
     # The mappings for XML -> Object translation. This will tell the function
     # to get the firstName element and assign it to the first_name attribute on
@@ -128,15 +130,14 @@ def test_object_does_not_have_xml_property(person_xml, mini_mock):
 
     # We will not setup the mock this time to verify that the function
     # will still add those attributes.
-    person0 = mini_mock()
-    person1 = deepcopy(person0)
+    person = mini_mock()
 
     mapping = {
         '@namespaces': {'x': 'http://example.com/namespace'},
         'nickname': ['x:nickname']}
-    bagatom.updateObjectFromXML(tree, person1, mapping)
+    bagatom.updateObjectFromXML(tree, person, mapping)
 
-    assert person1.nickname == 'Jim'
+    assert person.nickname == 'Jim'
 
 
 def test_xml_does_not_have_property(person_xml, mini_mock):
@@ -146,8 +147,7 @@ def test_xml_does_not_have_property(person_xml, mini_mock):
     """
     tree = etree.fromstring(person_xml)
 
-    person0 = mini_mock()
-    person1 = deepcopy(person0)
+    person = mini_mock()
 
     # The phone element does not exist in the XML that is being passed into
     # updateObjectFromXML.
@@ -155,11 +155,9 @@ def test_xml_does_not_have_property(person_xml, mini_mock):
         '@namespaces': {'x': 'http://example.com/namespace'},
         'phone': ['x:phone']
     }
-    bagatom.updateObjectFromXML(tree, person1, mapping)
+    bagatom.updateObjectFromXML(tree, person, mapping)
 
-    assert hasattr(person0, 'phone') is False
-    # Assert that the returned object does not include the phone attribute.
-    assert hasattr(person1, 'phone') is False
+    assert hasattr(person, 'phone') is False
 
 
 def test_object_returns_unmodified(person_xml, mini_mock):
@@ -170,7 +168,7 @@ def test_object_returns_unmodified(person_xml, mini_mock):
     tree = etree.fromstring(person_xml)
 
     person0 = mini_mock()
-    person1 = deepcopy(person0)
+    person1 = mini_mock()
 
     mapping = {}
     bagatom.updateObjectFromXML(tree, person1, mapping)
@@ -182,7 +180,6 @@ def test_mapping_w_namespaces(event_atom):
     Check that properties are mapped as expected from xml documents
     with multiple namespaces.
     """
-
     atom_tree = etree.fromstring(event_atom)
     event_tree = atom_tree.xpath(
         '//atom:content/premis:event', namespaces={
@@ -199,10 +196,7 @@ def test_mapping_w_namespaces(event_atom):
         '/premis:eventOutcome'
     map_dict['event_outcome_detail'] = 'premis:eventOutcomeInformation' +\
         '/premis:eventOutcomeDetail/premis:eventOutcomeDetailNote'
-
-    person0 = mini_mock()
-    person1 = deepcopy(person0)
-
-    bagatom.updateObjectFromXML(event_tree, person1, map_dict)
-
-    assert person0.event_outcome == person1.event_outcome
+    expected = 'http://purl.org/net/untl/vocabularies/eventOutcomes/#success'
+    event = mini_mock()
+    bagatom.updateObjectFromXML(event_tree, event, map_dict)
+    assert expected == event.event_outcome.strip()

--- a/tests/bagatom/test_updateObjectFromXML.py
+++ b/tests/bagatom/test_updateObjectFromXML.py
@@ -175,7 +175,7 @@ def test_object_returns_unmodified(person_xml, mini_mock):
     assert person0.__dict__ == person1.__dict__
 
 
-def test_mapping_w_namespaces(event_atom):
+def test_mapping_w_namespaces(event_atom, mini_mock):
     """
     Check that properties are mapped as expected from xml documents
     with multiple namespaces.

--- a/tests/bagatom/test_updateObjectFromXML.py
+++ b/tests/bagatom/test_updateObjectFromXML.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 
 from lxml import etree
-from mock import Mock
 import pytest
 
 from codalib import bagatom
@@ -9,11 +8,71 @@ from codalib import bagatom
 
 @pytest.fixture(scope='module')
 def person_xml():
-    return """<person xmlns="http://example.com/namespace">
-                  <firstName>James</firstName>
-                  <lastName>Doe</lastName>
-                  <nickname>Jim</nickname>
-              </person>
+    return """<?xml version="1.0"?>
+        <person xmlns="http://example.com/namespace">
+            <firstName>James</firstName>
+            <lastName>Doe</lastName>
+            <nickname>Jim</nickname>
+        </person>
+    """
+
+
+@pytest.fixture(scope='module')
+def event_atom():
+    return """<?xml version="1.0"?>
+        <entry xmlns="http://www.w3.org/2005/Atom">
+        <title>Atom-Powered Robots Run Amok</title>
+        <link href="http://example.org/2003/12/13/atom03" />
+        <link rel="alternate" type="text/html" href="http://example.org/2003/12/13/atom03.html"/>
+        <link rel="edit" href="http://example.org/2003/12/13/atom03/edit"/>
+        <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+        <updated>2003-12-13T18:30:02Z</updated>
+        <summary>Some text.</summary>
+        <content>
+            <premis:event xmlns:premis="info:lc/xmlns/premis-v2">
+                <premis:eventIdentifier>
+                    <premis:eventIdentifierType>
+                        http://purl.org/net/untl/vocabularies/identifier-qualifiers/#UUID
+                    </premis:eventIdentifierType>
+                    <premis:eventIdentifierValue>
+                        9e42cbd3cc3b4dfc888522036bbc4491
+                    </premis:eventIdentifierValue>
+                </premis:eventIdentifier>
+                <premis:eventType>
+                    http://purl.org/net/untl/vocabularies/preservationEvents/#fixityCheck
+                </premis:eventType>
+                <premis:eventDateTime>2013-05-13T14:14:55Z</premis:eventDateTime>
+                <premis:eventDetail>THIS IS EDITING THE EVENT DETAIL</premis:eventDetail>
+                <premis:eventOutcomeInformation>
+                    <premis:eventOutcome>
+                        http://purl.org/net/untl/vocabularies/eventOutcomes/#success
+                    </premis:eventOutcome>
+                    <premis:eventOutcomeDetail>
+                        <premis:eventOutcomeDetailNote>
+                            Total time for verification: 0:00:01.839590
+                        </premis:eventOutcomeDetailNote>
+                    </premis:eventOutcomeDetail>
+                </premis:eventOutcomeInformation>
+                <premis:linkingAgentIdentifier>
+                    <premis:linkingAgentIdentifierType>
+                        http://purl.org/net/untl/vocabularies/identifier-qualifiers/#URL
+                    </premis:linkingAgentIdentifierType>
+                    <premis:linkingAgentIdentifierValue>
+                        http://localhost:8787/agent/codaMigrationVerification
+                    </premis:linkingAgentIdentifierValue>
+                </premis:linkingAgentIdentifier>
+                <premis:linkingObjectIdentifier>
+                    <premis:linkingObjectIdentifierType>
+                        http://purl.org/net/untl/vocabularies/identifier-qualifiers/#ARK
+                    </premis:linkingObjectIdentifierType>
+                    <premis:linkingObjectIdentifierValue>
+                        ark:/67531/coda10kx
+                    </premis:linkingObjectIdentifierValue>
+                    <premis:linkingObjectRole/>
+                </premis:linkingObjectIdentifier>
+            </premis:event>
+        </content>
+    </entry>
     """
 
 
@@ -39,23 +98,25 @@ def test_object_properties_match_xml(person_xml, mini_mock):
     tree = etree.fromstring(person_xml)
 
     # Set up some blank object attributes.
-    return_object = mini_mock()
-    return_object.nickname = None
-    return_object.first_name = None
+    person0 = mini_mock()
+    person0.nickname = None
+    person0.first_name = None
 
-    # A mock function for the XMLToObjectFunc parameter. We will make a copy of
-    # the object to return to ensure that we do not mutate it in the test.
-    xmlToObject = Mock(return_value=deepcopy(return_object))
+    person1 = deepcopy(person0)
 
     # The mappings for XML -> Object translation. This will tell the function
     # to get the firstName element and assign it to the first_name attribute on
     # the object. It will do the same for nickname.
-    updateList = {'nickname': ['nickname'], 'first_name': ['firstName']}
-    updated_object = bagatom.updateObjectFromXML(
-        tree, xmlToObject, None, None, updateList)
+    mapping = {
+        '@namespaces': {'x': 'http://example.com/namespace'},
+        'nickname': ['x:nickname'], 'first_name': ['x:firstName']
+    }
+    bagatom.updateObjectFromXML(tree, person1, mapping)
 
-    assert updated_object.nickname == 'Jim'
-    assert updated_object.first_name == 'James'
+    assert person0.nickname != person1.nickname
+    assert person0.first_name != person1.first_name
+    assert person1.nickname == 'Jim'
+    assert person1.first_name == 'James'
 
 
 def test_object_does_not_have_xml_property(person_xml, mini_mock):
@@ -67,14 +128,15 @@ def test_object_does_not_have_xml_property(person_xml, mini_mock):
 
     # We will not setup the mock this time to verify that the function
     # will still add those attributes.
-    return_object = mini_mock()
-    xmlToObject = Mock(return_value=deepcopy(return_object))
+    person0 = mini_mock()
+    person1 = deepcopy(person0)
 
-    updateList = {'nickname': ['nickname']}
-    updated_object = bagatom.updateObjectFromXML(
-        tree, xmlToObject, None, None, updateList)
+    mapping = {
+        '@namespaces': {'x': 'http://example.com/namespace'},
+        'nickname': ['x:nickname']}
+    bagatom.updateObjectFromXML(tree, person1, mapping)
 
-    assert updated_object.nickname == 'Jim'
+    assert person1.nickname == 'Jim'
 
 
 def test_xml_does_not_have_property(person_xml, mini_mock):
@@ -84,17 +146,20 @@ def test_xml_does_not_have_property(person_xml, mini_mock):
     """
     tree = etree.fromstring(person_xml)
 
-    return_object = mini_mock()
-    xmlToObject = Mock(return_value=deepcopy(return_object))
+    person0 = mini_mock()
+    person1 = deepcopy(person0)
 
     # The phone element does not exist in the XML that is being passed into
     # updateObjectFromXML.
-    updateList = {'phone': ['phone']}
-    updated_object = bagatom.updateObjectFromXML(
-        tree, xmlToObject, None, None, updateList)
+    mapping = {
+        '@namespaces': {'x': 'http://example.com/namespace'},
+        'phone': ['x:phone']
+    }
+    bagatom.updateObjectFromXML(tree, person1, mapping)
 
+    assert hasattr(person0, 'phone') is False
     # Assert that the returned object does not include the phone attribute.
-    assert hasattr(updated_object, 'phone') is False
+    assert hasattr(person1, 'phone') is False
 
 
 def test_object_returns_unmodified(person_xml, mini_mock):
@@ -104,11 +169,40 @@ def test_object_returns_unmodified(person_xml, mini_mock):
     """
     tree = etree.fromstring(person_xml)
 
-    return_object = mini_mock()
-    xmlToObject = Mock(return_value=deepcopy(return_object))
+    person0 = mini_mock()
+    person1 = deepcopy(person0)
 
-    updateList = {}
-    updated_object = bagatom.updateObjectFromXML(
-        tree, xmlToObject, None, None, updateList)
+    mapping = {}
+    bagatom.updateObjectFromXML(tree, person1, mapping)
+    assert person0.__dict__ == person1.__dict__
 
-    assert dir(updated_object) == dir(return_object)
+
+def test_mapping_w_namespaces(event_atom):
+    """
+    Check that properties are mapped as expected from xml documents
+    with multiple namespaces.
+    """
+
+    atom_tree = etree.fromstring(event_atom)
+    event_tree = atom_tree.xpath(
+        '//atom:content/premis:event', namespaces={
+            'atom': 'http://www.w3.org/2005/Atom',
+            'premis': 'info:lc/xmlns/premis-v2'
+        }
+    )
+    event_tree = event_tree[0]
+    map_dict = {}
+    map_dict['@namespaces'] = {
+        'premis': 'info:lc/xmlns/premis-v2'
+    }
+    map_dict['event_outcome'] = 'premis:eventOutcomeInformation' +\
+        '/premis:eventOutcome'
+    map_dict['event_outcome_detail'] = 'premis:eventOutcomeInformation' +\
+        '/premis:eventOutcomeDetail/premis:eventOutcomeDetailNote'
+
+    person0 = mini_mock()
+    person1 = deepcopy(person0)
+
+    bagatom.updateObjectFromXML(event_tree, person1, map_dict)
+
+    assert person0.event_outcome == person1.event_outcome


### PR DESCRIPTION
…in updateObjectFromXML, got rid of callable arg -- a prelude to potentially refactoring (de)serialization of coda/premis/other objects to/from xml...if that's something we want to do.

In any case, this should solve the problem described in #21, though it will require a very small change to PREMIS event service.