### PR TITLE
Use unittest.mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 2.0.0
 -----
-* Upgrade to python3.
+* Upgrade to python3. [#29](https://github.com/unt-libraries/codalib/issues/29)
 
 1.0.3
 -----

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 pytest>=2.6.4
-mock>=1.0.1
 lxml>=3.3.0
 pytz>=2016.10
 tzlocal>=1.3

--- a/tests/bagatom/test_bagToXML.py
+++ b/tests/bagatom/test_bagToXML.py
@@ -1,6 +1,6 @@
 import os
+from unittest.mock import mock_open, patch
 
-from mock import mock_open, patch
 import pytest
 
 from codalib import bagatom

--- a/tests/bagatom/test_getters.py
+++ b/tests/bagatom/test_getters.py
@@ -1,6 +1,7 @@
-from lxml import etree
-from mock import mock_open, patch
+from unittest.mock import mock_open, patch
+
 import pytest
+from lxml import etree
 
 from codalib import bagatom
 

--- a/tests/bagatom/test_makeObjectFeed.py
+++ b/tests/bagatom/test_makeObjectFeed.py
@@ -1,6 +1,8 @@
+from unittest.mock import Mock
+
 from lxml import etree
+
 from codalib.bagatom import makeObjectFeed, ATOM_NAMESPACE as atom_ns
-from mock import Mock
 
 
 def test_simpleFeed():

--- a/tests/util/test_deleteQueue.py
+++ b/tests/util/test_deleteQueue.py
@@ -1,4 +1,5 @@
-from mock import Mock
+from unittest.mock import Mock
+
 import pytest
 
 from codalib import util

--- a/tests/util/test_doWaitWebRequest.py
+++ b/tests/util/test_doWaitWebRequest.py
@@ -1,6 +1,5 @@
+from unittest.mock import Mock
 from urllib.error import URLError
-
-from mock import Mock
 
 from codalib import util
 

--- a/tests/util/test_doWebRequest.py
+++ b/tests/util/test_doWebRequest.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 
 from codalib import util
 

--- a/tests/util/test_parseVocabularySources.py
+++ b/tests/util/test_parseVocabularySources.py
@@ -1,6 +1,6 @@
 import json
+from unittest.mock import mock_open, patch
 
-from mock import mock_open, patch
 import pytest
 
 from codalib import util

--- a/tests/util/test_sendPREMISEvent.py
+++ b/tests/util/test_sendPREMISEvent.py
@@ -1,7 +1,7 @@
 from datetime import datetime
+from unittest.mock import Mock, patch, mock_open, call
 from urllib.error import URLError
 
-from mock import Mock, patch, mock_open, call
 import pytest
 
 from codalib import util

--- a/tests/util/test_updateQueue.py
+++ b/tests/util/test_updateQueue.py
@@ -1,6 +1,6 @@
+from unittest.mock import Mock
 from urllib.error import URLError
 
-from mock import Mock
 import pytest
 
 from codalib import util

--- a/tests/util/test_waitForURL.py
+++ b/tests/util/test_waitForURL.py
@@ -1,8 +1,7 @@
 from time import sleep
+from unittest.mock import MagicMock
 import urllib.request
 import urllib.error
-
-from mock import MagicMock
 
 from codalib.util import waitForURL
 


### PR DESCRIPTION
This switches us off of the `mock` dependency for Python 3 (getting ready to merge py3 to master). ping @somexpert @madhulika95b 