### PR TITLE
Upgrade for tzlocal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 -----
 
 * Add support for Node `status` attribute.
+* Upgrade for `tzlocal` 3.0 dependency.
+* Drop support for now unsupported Python 3.5.
 
 2.0.0
 -----

--- a/codalib/xsdatetime.py
+++ b/codalib/xsdatetime.py
@@ -161,7 +161,7 @@ def localize_datetime(dt, local_tz=None):
     """
     if local_tz is None:
         local_tz = DEFAULT_LOCAL_TZ
-    return local_tz.localize(dt)
+    return dt.replace(tzinfo=local_tz)
 
 
 def current_offset(local_tz=None):
@@ -172,8 +172,7 @@ def current_offset(local_tz=None):
     """
     if local_tz is None:
         local_tz = DEFAULT_LOCAL_TZ
-    dt = local_tz.localize(datetime.now())
-    return dt.utcoffset()
+    return local_tz.utcoffset(datetime.now())
 
 
 def set_default_local_tz(new_local_tz):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 pytest>=2.6.4
 lxml>=3.3.0
 pytz>=2016.10
-tzlocal>=1.3
+tzlocal>=3.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('codalib/__init__.py', 'r') as fd:
 install_requires = [
     'lxml>=3.3',
     'pytz>=2016.10',
-    'tzlocal>=1.3'
+    'tzlocal>=3.0'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ]

--- a/tests/util/test_xsDateTime.py
+++ b/tests/util/test_xsDateTime.py
@@ -10,7 +10,7 @@ from tzlocal import get_localzone
 # Get the utc offset for the datetime object used in tests in local time.
 # we have to do this so tests will work during dst and std time.
 DEFAULT_LOCAL_TZ = get_localzone()
-LOCAL_OFFSET = DEFAULT_LOCAL_TZ.localize(datetime(2017, 1, 27, 14, 43)).utcoffset()
+LOCAL_OFFSET = DEFAULT_LOCAL_TZ.utcoffset(datetime(2017, 1, 27, 14, 43))
 
 
 def test_parse_date():
@@ -47,7 +47,7 @@ def test_parse_with_nondefault_timezone():
     dt_str = "2017-01-27T15:14:00.111111+06:00"
     dt = xsDateTime_parse(dt_str, local_tz=timezone("US/Pacific"))
     equiv = datetime(2017, 1, 27, 9, 14, 0, 111111)
-    equiv += timezone("US/Pacific").localize(datetime(2017, 1, 27, 9, 14, 0, 111111)).utcoffset()
+    equiv += timezone("US/Pacific").utcoffset(datetime(2017, 1, 27, 9, 14, 0, 111111))
     assert dt == equiv
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 max-line-length = 99
 
 [tox]
-envlist = py{35,36,37},py37-flake8
+envlist = py{36,37},py37-flake8
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
tzlocal version 3.0 now uses tzinfo objects for timezone information, so this PR modifies the code to work with that type. Also, Python 3.5 was end-of-life in September of 2020, so this removes testing in that environment.

This is ready for review @somexpert @gracieflores 