### PR TITLE
Expect the correct `type` to avoid looping unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.1.0
 -----
 
+* Fix looping indefinitely in util.waitForURL. [#38](https://github.com/unt-libraries/codalib/pull/38)
 * Add support for Node `status` attribute.
 * Upgrade for `tzlocal` 3.0 dependency.
 * Drop support for now unsupported Python 3.5.

--- a/codalib/util.py
+++ b/codalib/util.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import http.client
 import json
 import os
 import tempfile
@@ -57,7 +58,7 @@ def waitForURL(url, max_seconds=None):
             response = urllib.request.urlopen(HEADREQUEST(url))
         except urllib.error.URLError:
             pass
-        if response is not None and isinstance(response, urllib.request.addinfourl):
+        if response is not None and isinstance(response, http.client.HTTPResponse):
             if response.getcode() == 200:
                 # We're done, yay!
                 return
@@ -65,7 +66,7 @@ def waitForURL(url, max_seconds=None):
         timePassed = timeNow - startTime
         if max_seconds and max_seconds < timePassed.seconds:
             return
-        print("Waiting on URL %s for %s so far" % (url, timePassed))
+        print("%s: Waiting on URL %s for %s so far" % (str(timeNow), url, timePassed))
         time.sleep(30)
 
 

--- a/tests/util/test_waitForURL.py
+++ b/tests/util/test_waitForURL.py
@@ -1,6 +1,6 @@
 from time import sleep
 from unittest.mock import MagicMock
-import urllib.request
+import http.client
 import urllib.error
 
 from codalib.util import waitForURL
@@ -12,7 +12,7 @@ def test_url_call_succeeds_with_200(monkeypatch):
     200 OK.
     """
     # Setup the mocks.
-    response = MagicMock(spec=urllib.request.addinfourl)
+    response = MagicMock(spec=http.client.HTTPResponse)
     response.getcode.return_value = 200
     mock_urlopen = MagicMock(return_value=response)
 
@@ -30,7 +30,7 @@ def test_excepts_URLError(monkeypatch):
     Check that the function can handle urllib.request.URLErrors and
     immediately retry.
     """
-    response = MagicMock(spec=urllib.request.addinfourl)
+    response = MagicMock(spec=http.client.HTTPResponse)
     response.getcode.return_value = 200
 
     side_effects = [urllib.error.URLError('Mock Exception'), response]


### PR DESCRIPTION
This small change updates the code to look for the correct expected type for a response object. Recently the wait for looping was not hitting the expected exit condition. This also adds a timestamp when we hit a wait incident.